### PR TITLE
Add DMA Transfer Driver and Documentation

### DIFF
--- a/Drivers/DMATransfer_README.md
+++ b/Drivers/DMATransfer_README.md
@@ -1,0 +1,81 @@
+# DMA Transfer Driver
+
+**Author:** Javier  
+**Date:** 2026-01-10  
+**Status:** Active  
+
+## Overview
+
+The **DMA Transfer Driver** is a header-only abstraction layer designed to simplify Direct Memory Access (DMA) transfers for STM32 peripherals. It provides a single, unified static interface (`DMAControl::Transfer`) that automatically handles protocol-specific HAL calls for **SPI**, **I2C**, and **UART**.
+
+This driver also manages **Cache Coherence** for Cortex-M7 (STM32H7) and Cortex-M4 (STM32G4) devices, ensuring that data located in D-Cache is properly cleaned (flushed) to RAM before transmission or invalidated (refreshed) from RAM after reception.
+
+## Features
+
+* **Unified Interface:** Uses C++ `if constexpr` templates to detect the handle type (`SPI_HandleTypeDef`, `I2C_HandleTypeDef`, `UART_HandleTypeDef`) and call the matching HAL function.
+* **Cache Management:** Automatically calls `SCB_CleanDCache_by_Addr` and `SCB_InvalidateDCache_by_Addr` if the architecture requires it (H7/G4).
+* **Zero-Overhead:** Being header-only template library, the compiler optimizes unused branches, resulting in no runtime performance penalty compared to raw HAL calls.
+
+## Directory Structure
+
+* **Header:** `SoarOS/Drivers/Inc/DMATransfer.hpp`
+* **Documentation:** `SoarOS/Drivers/DMATransfer_README.md`
+
+## API Reference
+
+```cpp
+static HAL_StatusTypeDef Transfer(
+    HandleType* handle,   // Pointer to the HAL handle (e.g., &hspi1, &hi2c1, &huart2)
+    uint16_t devAddr,     // Device Address (Used for I2C only; set to 0 for others)
+    uint8_t* txData,      // Pointer to Transmit Buffer (nullptr if receive-only)
+    uint8_t* rxData,      // Pointer to Receive Buffer (nullptr if transmit-only)
+    uint16_t size         // Number of bytes to transfer
+);
+```
+
+## Usage
+
+### Include the Header
+
+```cpp
+#include "DMATransfer.hpp"
+```
+
+### I2C
+
+```cpp
+// Example: Write 4 bytes to an EEPROM at address 0x50
+uint8_t data[] = {0x00, 0x01, 0xAA, 0xBB};
+DMAControl::Transfer(&hi2c1, (0x50 << 1), data, nullptr, 4);
+
+// Example: Read 10 bytes from a sensor at address 0x68
+uint8_t rxBuffer[10];
+DMAControl::Transfer(&hi2c1, (0x68 << 1), nullptr, rxBuffer, 10);
+```
+
+### SPI
+
+```cpp
+uint8_t txBuf[] = {0xCA, 0xFE};
+uint8_t rxBuf[2];
+
+// Full Duplex Transfer
+DMAControl::Transfer(&hspi1, 0, txBuf, rxBuf, 2);
+```
+
+### UART
+
+```cpp
+// Transmit Message via DMA
+uint8_t msg[] = "Hello World";
+DMAControl::Transfer(&huart1, 0, msg, nullptr, 11);
+
+// Receive Data via DMA
+uint8_t inputBuf[64];
+DMAControl::Transfer(&huart1, 0, nullptr, inputBuf, 64);
+```
+
+### NOTES
+
+* This Driver Requires HAL handles. It is not directly compatible with LL pointers without a wrapper.
+* DMA channels should be enabled and linked to peripherals in main.c / msp.c before calling this function.

--- a/Drivers/Inc/DMATransfer.hpp
+++ b/Drivers/Inc/DMATransfer.hpp
@@ -1,0 +1,71 @@
+ /**
+ ********************************************************************************
+ * @file    DMATransfer.hpp
+ * @author  Javier
+ * @date    2026-01-10
+ * @brief   Header for the DMA Transfer Driver.
+ ********************************************************************************
+ */
+
+#ifndef CUBE_DMATRANSFER_HPP
+#define CUBE_DMATRANSFER_HPP
+
+/************************************
+ * INCLUDES
+ ************************************/
+//#include "main.h"
+#include "SystemDefines.hpp"
+#include "cmsis_os.h"
+#include <type_traits>
+
+/************************************
+ * CLASS DEFINITIONS
+ ************************************/
+class DMAControl {
+public:
+    template <typename HandleType>
+    static HAL_StatusTypeDef Transfer(HandleType* handle, uint16_t devAddr, uint8_t* txData, uint8_t* rxData, uint16_t size) {
+        
+        // H7 / G4      Cache Management
+        #if defined(STM32H7) || defined(STM32G4)
+            // Cache To RAM before DMA
+            if (txData != nullptr) SCB_CleanDCache_by_Addr((uint32_t*)txData, size);
+            // Clean Cache to Force read RAM
+            if (rxData != nullptr) SCB_InvalidateDCache_by_Addr((uint32_t*)rxData, size);
+        #endif
+
+        // ===   SPI Logic   ===
+        if constexpr (std::is_same_v<HandleType, SPI_HandleTypeDef>) {
+            // SPI Transfer (Full-Duplex)
+            return HAL_SPI_TransmitReceive_DMA(handle, txData, rxData, size);
+        }
+
+        // ===   I2C Logic   ===
+        if constexpr (std::is_same_v<HandleType, I2C_HandleTypeDef>) {
+            
+            // Transmit
+            if (txData != nullptr && rxData == nullptr) {
+                return HAL_I2C_Master_Transmit_DMA(handle, devAddr, txData, size);
+            }
+            
+            // Receive
+            else if (rxData != nullptr && txData == nullptr) {
+                return HAL_I2C_Master_Receive_DMA(handle, devAddr, rxData, size);
+            }
+        }
+            // ===   UART Logic   ===
+        if constexpr (std::is_same_v<HandleType, UART_HandleTypeDef>) {
+            // Transmit
+            if (txData != nullptr && rxData == nullptr) {
+                return HAL_UART_Transmit_DMA(handle, txData, size);
+            }
+            // Receive
+            else if (rxData != nullptr && txData == nullptr) {
+                return HAL_UART_Receive_DMA(handle, rxData, size);
+            }
+        }
+        return HAL_ERROR;
+    }
+};
+
+#endif /* CUBE_DMATRANSFER_HPP */


### PR DESCRIPTION
Introduce a header-only DMA Transfer Driver that simplifies DMA operations for STM32 peripherals, including SPI, I2C, and UART. The implementation includes cache management for specific STM32 architectures and provides a unified interface for ease of use. Documentation is also added to guide users on how to implement the driver.